### PR TITLE
fix: allow min max object (typescript)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,10 @@ export declare function addXP(
   message: Message,
   userID: string,
   guildID: string,
-  xp: number
+  xp: {
+    min: number,
+    max: number
+}
 ): Promise<any>
 
 export type chartsOptions = {


### PR DESCRIPTION
Typescript users were unable to use the xp randomizer as it was returning the wrong types.

# Information
Created an object of numbers instead of a number in the index file.

# Checks
- [ ✔] Does the package work as intended?
